### PR TITLE
Vda: Fixing dependencies for vda-1

### DIFF
--- a/vala/vapi/vda-1.deps
+++ b/vala/vapi/vda-1.deps
@@ -1,1 +1,3 @@
+gio-2.0
 gee-0.8
+gcalc-1


### PR DESCRIPTION
Fixes when VDA is used not as a Meson  subproject.

This adds GCal dependency on deps file.